### PR TITLE
Add spend per day breakpoint script

### DIFF
--- a/detect_spend_breakpoints.py
+++ b/detect_spend_breakpoints.py
@@ -1,0 +1,197 @@
+import argparse
+import json
+from typing import Optional, Tuple, List
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+import ruptures as rpt
+import matplotlib.pyplot as plt
+
+
+def load_cases(path: str) -> pd.DataFrame:
+    """Load JSON cases file into DataFrame."""
+    with open(path, "r") as f:
+        data = json.load(f)
+    records = []
+    for case in data:
+        inp = case.get("input", {})
+        days = inp.get("trip_duration_days")
+        receipts = inp.get("total_receipts_amount")
+        records.append(
+            {
+                "days": days,
+                "miles": inp.get("miles_traveled"),
+                "receipts": receipts,
+                "payout": case.get("expected_output"),
+                "spd": receipts / days if days else 0,
+            }
+        )
+    return pd.DataFrame(records)
+
+
+def filter_cases(
+    df: pd.DataFrame,
+    days_min: int,
+    days_max: int,
+    miles_min: float,
+    miles_max: float,
+) -> pd.DataFrame:
+    mask = (
+        (df["days"] >= days_min)
+        & (df["days"] <= days_max)
+        & (df["miles"] >= miles_min)
+        & (df["miles"] <= miles_max)
+    )
+    return df.loc[mask].copy()
+
+
+def compute_local_slope(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_values("spd").reset_index(drop=True)
+    slopes = np.gradient(df["payout"], df["spd"])
+    df["local_slope"] = slopes
+    return df
+
+
+def run_pelt_breakpoints(values: np.ndarray) -> List[int]:
+    algo = rpt.Pelt(model="l2").fit(values)
+    idx = algo.predict(pen=10)
+    # omit last index equal to len(values)
+    return idx[:-1]
+
+
+def add_spd_segments(df: pd.DataFrame, k1: float, k2: Optional[float] = None) -> pd.DataFrame:
+    """Add piecewise linear segment columns based on knots."""
+    s = df["spd"].values
+    seg1 = np.minimum(s, k1)
+    if k2 is None:
+        seg2 = np.maximum(0, s - k1)
+        seg3 = np.zeros_like(s)
+    else:
+        seg2 = np.maximum(0, np.minimum(s, k2) - k1)
+        seg3 = np.maximum(0, s - k2)
+    df = df.copy()
+    df["spd_seg1"] = seg1
+    df["spd_seg2"] = seg2
+    df["spd_seg3"] = seg3
+    return df
+
+
+def fit_hinge(df: pd.DataFrame, k1: float, k2: Optional[float] = None) -> Tuple[float, LinearRegression]:
+    df_seg = add_spd_segments(df, k1, k2)
+    features = ["spd_seg1", "spd_seg2"] if k2 is None else ["spd_seg1", "spd_seg2", "spd_seg3"]
+    X = df_seg[features].values
+    y = df_seg["payout"].values
+    model = LinearRegression().fit(X, y)
+    pred = model.predict(X)
+    rss = np.sum((y - pred) ** 2)
+    n = len(y)
+    p = X.shape[1] + 1
+    aic = n * np.log(rss / n) + 2 * p
+    return aic, model
+
+
+def choose_one_knot(df: pd.DataFrame, candidates: List[int]) -> Tuple[int, LinearRegression]:
+    best_aic = float("inf")
+    best_k = candidates[0]
+    best_model = None
+    for k in candidates:
+        aic, model = fit_hinge(df, k)
+        if aic < best_aic:
+            best_aic = aic
+            best_k = k
+            best_model = model
+    return best_k, best_model
+
+
+def choose_two_knots(df: pd.DataFrame, candidates: List[int]) -> Tuple[Tuple[int, int], LinearRegression]:
+    pairs = [(c1, c2) for c1 in candidates for c2 in candidates if c1 < c2]
+    best_aic = float("inf")
+    best_pair = pairs[0]
+    best_model = None
+    for k1, k2 in pairs:
+        aic, model = fit_hinge(df, k1, k2)
+        if aic < best_aic:
+            best_aic = aic
+            best_pair = (k1, k2)
+            best_model = model
+    return best_pair, best_model
+
+
+def save_plots(df: pd.DataFrame, output_prefix: str) -> None:
+    plt.figure(figsize=(8, 6))
+    plt.scatter(df["spd"], df["payout"], alpha=0.6)
+    plt.xlabel("Spend per Day")
+    plt.ylabel("Payout")
+    plt.title("Spend per Day vs Payout")
+    plt.tight_layout()
+    plt.savefig(f"{output_prefix}_scatter.png")
+    plt.close()
+
+    plt.figure(figsize=(8, 6))
+    plt.plot(df["spd"], df["local_slope"], marker="o", linestyle="-")
+    plt.xlabel("Spend per Day")
+    plt.ylabel("Local slope")
+    plt.title("Local Slope of Payout vs Spend per Day")
+    plt.tight_layout()
+    plt.savefig(f"{output_prefix}_slope.png")
+    plt.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Detect spend-per-day breakpoints")
+    parser.add_argument("cases", nargs="?", default="public_cases.json")
+    parser.add_argument("--days-min", type=int, default=4)
+    parser.add_argument("--days-max", type=int, default=6)
+    parser.add_argument("--miles-min", type=float, default=550)
+    parser.add_argument("--miles-max", type=float, default=650)
+    parser.add_argument("--two-knots", action="store_true")
+    args = parser.parse_args()
+
+    df = load_cases(args.cases)
+    df = filter_cases(df, args.days_min, args.days_max, args.miles_min, args.miles_max)
+    df = compute_local_slope(df)
+
+    break_idx = run_pelt_breakpoints(df["payout"].values)
+    break_spd = df.loc[break_idx, "spd"].tolist()
+
+    candidates = [50, 100, 150, 200, 400, 600, 800, 1000]
+
+    if args.two_knots:
+        (k1, k2), model = choose_two_knots(df, candidates)
+    else:
+        k1, model = choose_one_knot(df, candidates)
+        k2 = None
+
+    seg_df = add_spd_segments(df, k1, k2)
+    features = ["spd_seg1", "spd_seg2"] if k2 is None else ["spd_seg1", "spd_seg2", "spd_seg3"]
+    X = seg_df[features].values
+    y = seg_df["payout"].values
+    pred = model.predict(X)
+
+    if k2 is None:
+        slopes = [model.coef_[0], model.coef_[0] + model.coef_[1]]
+    else:
+        slopes = [model.coef_[0], model.coef_[0] + model.coef_[1], model.coef_[0] + model.coef_[1] + model.coef_[2]]
+
+    result = {
+        "knot_1": int(k1),
+        "knot_2": int(k2) if k2 is not None else None,
+        "slope_1": float(slopes[0]),
+        "slope_2": float(slopes[1]),
+    }
+    if k2 is not None:
+        result["slope_3"] = float(slopes[2])
+    with open("spend_segments.json", "w") as f:
+        json.dump(result, f, indent=2)
+
+    print("Detected breakpoints from PELT:", break_spd)
+    print("Selected knot(s):", k1 if k2 is None else (k1, k2))
+    print("Slopes:", slopes)
+
+    df["fitted"] = pred
+    save_plots(df, "spend")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- clone the mileage breakpoint detection script to analyze spend per day
- compute `total_receipts_amount / trip_duration_days` and detect hinge breakpoints using the same approach as the mileage tool
- output results to `spend_segments.json`

## Testing
- `python3 -m py_compile detect_spend_breakpoints.py`
- `python3 detect_spend_breakpoints.py public_cases.json --days-min 4 --days-max 6 --miles-min 550 --miles-max 650 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6844b83b95f083228ce6b715421945c0